### PR TITLE
Truly titanic pull request

### DIFF
--- a/client/details/DetailsApp.jsx
+++ b/client/details/DetailsApp.jsx
@@ -3,7 +3,10 @@ import ReactDOM from "react-dom";
 import $ from "jquery";
 import Grid from "@material-ui/core/Grid";
 import Paper from "@material-ui/core/Paper";
+import Rating from "@material-ui/lab/Rating";
+import axios from "axios";
 
+import Gallery from "./Gallery.jsx";
 import Heading from "./Heading.jsx";
 import StyleSelect from "./StyleSelect.jsx";
 import Pitch from "./Pitch.jsx";
@@ -38,12 +41,16 @@ var sampleStyles = [
     "default?": 1,
     photos: [
       {
-        thumbnail_url: "urlplaceholder/style_1_photo_number_thumbnail.jpg",
-        url: "urlplaceholder/style_1_photo_number.jpg",
+        thumbnail_url:
+          "https://images.unsplash.com/photo-1501088430049-71c79fa3283e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=668&q=80",
+        url:
+          "https://images.unsplash.com/photo-1501088430049-71c79fa3283e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=668&q=80",
       },
       {
-        thumbnail_url: "urlplaceholder/style_1_photo_number_thumbnail.jpg",
-        url: "urlplaceholder/style_1_photo_number.jpg",
+        thumbnail_url:
+          "https://images.unsplash.com/photo-1501088430049-71c79fa3283e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=668&q=80",
+        url:
+          "https://images.unsplash.com/photo-1501088430049-71c79fa3283e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=668&q=80",
       },
       // ...
     ],
@@ -64,8 +71,10 @@ var sampleStyles = [
     "default?": 0,
     photos: [
       {
-        thumbnail_url: "urlplaceholder/style_2_photo_number_thumbnail.jpg",
-        url: "urlplaceholder/style_2_photo_number.jpg",
+        thumbnail_url:
+          "https://images.unsplash.com/photo-1501088430049-71c79fa3283e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=668&q=80",
+        url:
+          "https://images.unsplash.com/photo-1501088430049-71c79fa3283e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=668&q=80",
       },
     ],
     skus: {
@@ -97,11 +106,11 @@ var sampleStyle = {
     // ...
   ],
   skus: {
-    XS: 8,
-    S: 16,
-    M: 17,
-    L: 10,
-    XL: 15,
+    1: {size: 'XS', quantity: 10},
+    2: {size: 'S', quantity: 12},
+    3: {size: 'M', quantity: 9},
+    4: {size: 'L', quantity: 11},
+    5: {size: 'XL', quantity: 16},
   },
 };
 
@@ -112,7 +121,26 @@ class Details extends React.Component {
       currentProduct: sampleData,
       currentStyles: sampleStyles,
       currentStyle: sampleStyle,
-      currentSize: "XS",
+      currentSku: '1',
+      cart: [],
+      size: 'select size',
+      // currentPicUrl:
+      //   "https://images.unsplash.com/photo-1501088430049-71c79fa3283e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=668&q=80",
+      // pics: [
+      //   "https://images.unsplash.com/photo-1501088430049-71c79fa3283e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=668&q=80",
+      //   "https://images.unsplash.com/photo-1534011546717-407bced4d25c?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=2734&q=80",
+      //   "https://images.unsplash.com/photo-1549831243-a69a0b3d39e0?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=2775&q=80",
+      //   "https://images.unsplash.com/photo-1527522883525-97119bfce82d?ixlib=rb-1.2.1&auto=format&fit=crop&w=668&q=80",
+      //   "https://images.unsplash.com/photo-1556648202-80e751c133da?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=668&q=80",
+      // ],
+      // thumbnails: [
+      //   "https://images.unsplash.com/photo-1501088430049-71c79fa3283e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=300&q=80",
+      //   "https://images.unsplash.com/photo-1534011546717-407bced4d25c?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=300&q=80",
+      //   "https://images.unsplash.com/photo-1549831243-a69a0b3d39e0?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=300&q=80",
+      //   "https://images.unsplash.com/photo-1527522883525-97119bfce82d?ixlib=rb-1.2.1&auto=format&fit=crop&w=300&q=80",
+      //   "https://images.unsplash.com/photo-1556648202-80e751c133da?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=300&q=80",
+      // ],
+      // currentPic: 0,
       quantities: [
         "1",
         "2",
@@ -131,7 +159,105 @@ class Details extends React.Component {
         "15",
       ],
     };
+    // this.getPictures = this.getPictures.bind(this);
+    // this.handleLeftArrowClick = this.handleLeftArrowClick.bind(this);
+    // this.handleRightArrowClick = this.handleRightArrowClick.bind(this);
+    this.handleStyleChange = this.handleStyleChange.bind(this);
+    this.handleSizeChange = this.handleSizeChange.bind(this);
   }
+
+  handleStyleChange(style) {
+    var newStyle = style;
+    this.setState({
+      currentStyle: newStyle,
+    });
+  }
+
+  handleSizeChange(event) {
+    if (this.state.size !== event.target.value) {
+      var newSku = event.target.value;
+      this.setState({
+        currentSku: newSku,
+        currentSize: this.state.currentStyle.skus[event.target.value].size
+      });
+    }
+  }
+
+  componentDidMount() {
+    axios
+      .get(`http://18.224.37.110/products/1/styles`)
+      .then((res) => {
+        var currentStyles = res.data;
+        this.setState({
+          currentStyles: res.data.results,
+          currentStyle: res.data.results[0],
+        });
+        axios
+          .get(`http://18.224.37.110/products/1`)
+          .then((res) => {
+            var currentProduct = res.data;
+            this.setState({ currentProduct });
+          });
+      })
+      .catch((err) => {
+        console.log(err);
+      });
+  }
+
+  // getPictures() {
+  //   console.log('hello world');
+  //   var pics = [];
+  //   var thumbnails = [];
+  //   if (this.state.currentStyles) {
+  //     for (var i = 0; i < this.state.currentStyles.length; i++) {
+  //       if (this.state.currentStyles[i].photos) {
+  //         for (var k = 0; k < this.state.currentStyles[i].photos.length; i++) {
+  //           pics.push(this.state.currentStyles[i].photos[k].url);
+  //           thumbnails.push(this.state.currentStyles[i].photos[k].thumbnail_url);
+  //         }
+  //       }
+  //     }
+  //   }
+  //   this.setState({
+  //     pics: pics,
+  //     thumbnails: thumbnails,
+  //   });
+  // }
+
+  // handleLeftArrowClick() {
+  //   var index = this.state.currentPic;
+  //   if (this.state.currentPic === 0) {
+  //     var newIndex = this.state.pics.length - 1;
+  //     this.setState({
+  //       currentPic: newIndex,
+  //       currentPicUrl: this.state.pics[newIndex],
+  //     });
+  //   } else {
+  //     var newIndex = index - 1;
+  //     this.setState({
+  //       currentPic: newIndex,
+  //       currentPicUrl: this.state.pics[newIndex],
+  //     });
+  //   }
+  // }
+
+  // handleRightArrowClick() {
+  //   var index = this.state.currentPic;
+  //   if (this.state.currentPic === this.state.pics.length - 1) {
+  //     var newIndex = 0;
+  //     this.setState({
+  //       currentPic: newIndex,
+  //       currentPicUrl: this.state.pics[newIndex],
+  //     });
+  //   } else {
+  //     var newIndex = index + 1;
+  //     this.setState({
+  //       currentPic: newIndex,
+  //       currentPicUrl: this.state.pics[newIndex],
+  //     });
+  //   }
+  // }
+
 
   render() {
     return (
@@ -151,13 +277,17 @@ class Details extends React.Component {
               alignItems="stretch"
               spacing={8}
             >
-              <Grid item xs={8} spacing={0}>
+              <Grid item xs={8}>
                 <div id="gallery">
                   <Paper elevation={0}>
-                    <img
-                      src="https://i.imgur.com/Q2xzpwJ.png"
-                      id="placeholderpic"
-                    ></img>
+                    <Gallery
+                      // handleLeftArrowClick={this.handleLeftArrowClick}
+                      // handleRightArrowClick={this.handleRightArrowClick}
+                      // pics={this.state.pics}
+                      // thumbnails={this.state.thumbnails}
+                      // currentPicUrl={this.state.currentPicUrl}
+                      currentStyles={this.state.currentStyles}
+                    />
                   </Paper>
                 </div>
               </Grid>
@@ -165,7 +295,6 @@ class Details extends React.Component {
                 container
                 item
                 xs={4}
-                spacing={0}
                 direction="column"
                 justify="flex-start"
                 alignItems="flex-start"
@@ -177,12 +306,20 @@ class Details extends React.Component {
                     </div>
                     <div id="styleselect">
                       <StyleSelect
+                        tinyImage="https://www.thesprucepets.com/thmb/6xUaoRttXiA5XVTrsjWIwLsbNo8=/2248x2248/smart/filters:no_upscale()/kitten-looking-at-camera-521981437-57d840213df78c583374be3b.jpg"
                         currentProduct={this.state.currentProduct}
                         currentStyles={this.state.currentStyles}
                         currentStyle={this.state.currentStyle}
                         currentSize={this.state.currentSize}
                         quantities={this.state.quantities}
-                        sizes={["XS", "S", "M", "L", "XL"]}
+                        currentSku={this.state.currentSku}
+                        // currentQty={this.state.currentStyle.skus[this.state.currentSku].quantity}
+                        handleStyleChange={this.handleStyleChange}
+                        handleSizeChange={this.handleSizeChange}
+                        size={this.state.size}
+                        // sizes={Object.keys(this.state.currentStyle.skus)}
+                        // changeStyle={this.changeStyle}
+                        // thumbnails={this.state.thumbnails}
                       />
                     </div>
                   </Paper>
@@ -195,17 +332,17 @@ class Details extends React.Component {
                 container
                 direction="row"
                 justify="flex-start"
-                alignItems="stretch"
-                spacing={2}
+                alignItems="flex-start"
+                spacing={5}
               >
-                <Grid item xs={8} spacing={1}>
+                <Grid item xs={8}>
                   <div id="pitch">
                     <Paper elevation={0}>
                       <Pitch currentProduct={this.state.currentProduct} />
                     </Paper>
                   </div>
                 </Grid>
-                <Grid item xs={4} spacing={1}>
+                <Grid item xs={4}>
                   <div id="tickboxes">
                     <Paper elevation={0}>
                       <Tickboxes currentProduct={this.state.currentProduct} />

--- a/client/details/Gallery.jsx
+++ b/client/details/Gallery.jsx
@@ -1,0 +1,86 @@
+import React from "react";
+import Grid from "@material-ui/core/Grid";
+import Button from "@material-ui/core/Button";
+import IconButton from "@material-ui/core/IconButton";
+import { positions } from "@material-ui/system";
+// import FullscreenIcon from "@material-ui/icons/Fullscreen";
+// import ArrowBackIcon from "@material-ui/icons/ArrowBack";
+// import ArrowForwardIcon from "@material-ui/icons/ArrowForward";
+import Carousel from "react-bootstrap/Carousel";
+
+class Gallery extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {};
+  }
+
+  render() {
+    return (
+      <div>
+        <Grid container direction="column" spacing={0}>
+          <Grid item xs={12}>
+            <Carousel>
+              {this.props.currentStyles.map((style) => {
+                return (
+                  style.photos.map((photo) => {
+                    return (
+                      <Carousel.Item>
+                        <img
+                          src={photo.url}
+                          className="mainphoto"
+                          alt="photo of style"
+                        ></img>
+                      </Carousel.Item>
+                    );
+                  })
+                );
+              })}
+            </Carousel>
+          </Grid>
+          {/* <Grid item xs={12}>
+            <img src={this.props.currentPicUrl} id="mainphoto" />
+          </Grid>
+          <Grid
+            item
+            xs={2}
+            zindex={1000}
+            className="scrollable block"
+            container
+            direction="column"
+            justify="flex-start"
+            alignItems="baseline"
+          >
+            <IconButton>
+              <FullscreenIcon id="fs"/>
+            </IconButton>
+            {this.props.thumbnails.map((thumb) => {
+              return (
+                <img src={thumb} id="tiny" />
+              );
+            })}
+          </Grid>
+          <Grid
+            item
+            xs={4}
+            zindex={1000}
+            container
+            direction="row"
+            justify="space-between"
+            alignItems="center"
+            className="block"
+            id="arrows"
+          >
+            <IconButton>
+              <ArrowBackIcon onClick={this.props.handleLeftArrowClick} />
+            </IconButton>
+            <IconButton>
+              <ArrowForwardIcon onClick={this.props.handleRightArrowClick} />
+            </IconButton>
+          </Grid> */}
+        </Grid>
+      </div>
+    );
+  }
+}
+
+export default Gallery;

--- a/client/details/Heading.jsx
+++ b/client/details/Heading.jsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import Rating from '@material-ui/lab/Rating';
+
 const Heading = (props) => (
   <div>
     <div id="stars">☆☆☆☆☆ <u>Read all reviews</u></div>

--- a/client/details/Pitch.jsx
+++ b/client/details/Pitch.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 // import Grid from '@material-ui/core/Grid';
 
 const Pitch = (props) => (
-  <div>
+  <div id="pitch">
     <div id="slogan">{props.currentProduct.slogan}</div>
     <div id="desc">{props.currentProduct.description}</div>
   </div>

--- a/client/details/StyleSelect.jsx
+++ b/client/details/StyleSelect.jsx
@@ -1,39 +1,86 @@
-import React from 'react';
-// import Grid from '@material-ui/core/Grid';
+import React from "react";
+import Grid from "@material-ui/core/Grid";
+import Button from "@material-ui/core/Button";
+import Icon from "@material-ui/core/Icon";
+import IconButton from "@material-ui/core/IconButton";
+import AddIcon from "@material-ui/icons/Add";
+import StarBorderIcon from "@material-ui/icons/StarBorder";
 
 const StyleSelect = (props) => (
   <div>
+    {console.log(props)}
     <div id="price">$ {props.currentProduct.default_price}</div>
     <div id="styletext">
-      <strong>style: </strong> selected style
+      <strong>style: </strong> {props.currentStyle.name}
     </div>
     <div id="styleBubbles">
-      {props.currentStyles.map((style) => {
-        return (
-          <div className="style bubble">
-            <img src={style.photos[0].thumbnail_url}></img>
-          </div>
-        );
-      })}
-    </div>
-    <div className="dropdown" id="selectsize">
-      <select>
-        <option value="select size">select size</option>
-        {props.sizes.map((sku) => {
-          return <option value={sku}>{sku}</option>;
+      <Grid container direction="row" spacing={1}>
+        {props.currentStyles.map((style) => {
+          return (
+            <div
+              className="style bubble"
+              onClick={() => {
+                props.handleStyleChange(style);
+              }}
+            >
+              <Grid item xs={2}>
+                <img
+                  src={style.photos[0].thumbnail_url}
+                  className="styleBubble"
+                  title={style.name}
+                  id="bordered"
+                ></img>
+              </Grid>
+            </div>
+          );
         })}
-      </select>
+      </Grid>
     </div>
-    <div className="dropdown" id="selectqty">
-      <select>
-        {props.quantities.map((num) => {
-          return <option value={num}>{num}</option>;
-        })}
-      </select>
-    </div>
+    <Grid container direction="row" spacing={1}>
+      <Grid item xs={8}>
+        <div className="dropdown" className="selectsize">
+          <select className="selectsize" onChange={props.handleSizeChange}>
+            <option value="select size" className="selectsize">
+              select size
+            </option>
+            {Object.keys(props.currentStyle.skus).map((sku) => {
+              return (
+                <option
+                  value={sku}
+                  className="selectsize"
+                >
+                  {props.currentStyle.skus[sku].size}
+                </option>
+              );
+            })}
+          </select>
+        </div>
+      </Grid>
+      <Grid item xs={4}>
+        <div className="dropdown">
+          <select className="selectqty">
+            {props.quantities.map((num) => {
+              if (props.currentStyle.skus[props.currentSku] !== undefined) {
+                if (num <= props.currentStyle.skus[props.currentSku].quantity) {
+                  return <option value={num}>{num}</option>;
+                } else {
+                  return;
+                }
+              } else {
+                return <option value={num}>{num}</option>;
+              }
+            })}
+          </select>
+        </div>
+      </Grid>
+    </Grid>
     <div id="addto">
-      <button>add to bag</button>
-      <button>☆</button>
+      <Button variant="outlined" endIcon={<AddIcon />} id="addbag">
+        add to bag
+      </Button>
+      <IconButton>
+        <StarBorderIcon className="squared" id="staricon" />
+      </IconButton>
     </div>
   </div>
 );

--- a/client/details/Tickboxes.jsx
+++ b/client/details/Tickboxes.jsx
@@ -3,10 +3,11 @@ import React from 'react';
 
 const Tickboxes = (props) => (
   <div>
-    <div id="checked">✓ where is this data</div>
-    <div id="checked">✓ i have no idea</div>
-    <div id="checked">✓ it doesn't look like the features data</div>
-    <div id="checked">✓ but i guess it must be</div>
+    {props.currentProduct.features.map((feature) => {
+      return (
+        <div id="checked">✓ {feature.feature}: {feature.value}</div>
+      );
+    })}
   </div>
 );
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "jquery": "^3.5.1",
     "mysql": "^2.18.1",
     "react": "^16.13.1",
+    "react-bootstrap": "^1.3.0",
     "react-dom": "^16.13.1",
     "react-scripts": "^3.4.3"
   },

--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,9 @@
   <head>
     <title>Maruchan Instant Duds</title>
     <meta charset="UTF-8">
+    <link href="https://fonts.googleapis.com/css2?family=Lato:wght@100;300;400;700;900&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="stylesheet.css">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/latest/css/bootstrap.min.css">
   </head>
   <body>
     <div id="app"></div>

--- a/public/stylesheet.css
+++ b/public/stylesheet.css
@@ -1,8 +1,24 @@
-#placeholderpic {
+.mainphoto {
   height: 450px;
   width: 575px;
-  float: left;
-  display: flex;
+  object-fit: cover;
+  /* float: left;
+  z-index: 1; */
+}
+
+.block {
+  display: block;
+  position: absolute;
+}
+
+#tiny {
+  height: 50px;
+  width: 50px;
+  object-fit: cover;
+  border: 1px solid #525252;
+  margin-left: 15px;
+  margin-top: 10px;
+  cursor: pointer;
 }
 
 #overview {
@@ -17,25 +33,29 @@
   font-weight: 300;
   color: #525252;
   cursor: pointer;
+  margin-top: 40px;
 }
 
 #category {
   text-transform: uppercase;
-  font-size: 14px;
+  font-size: 11px;
   font-weight: 100;
   color: #525252;
+  margin-top: 14px;
 }
 
 #title {
   font-size: 30px;
   font-weight: 700;
   color: #525252;
+  margin-bottom: 10px;
 }
 
 #price {
   font-size: 14px;
   font-weight: 300;
   color: #525252;
+  margin-bottom: 12px;
 }
 
 #styletext {
@@ -43,13 +63,42 @@
   font-weight: 300;
   text-transform: uppercase;
   color: #525252;
+  margin-bottom: 6px;
+}
+
+.styleBubble {
+  height: 40px;
+  width: 40px;
+  object-fit: cover;
+  border-radius: 100%;
+  margin: 4px 0px 4px 8px;
+}
+
+#staricon {
+  height: 38px;
+  width: 38px;
+}
+
+.squared {
+  padding: 5px;
+  border: 1px solid #525252;
+}
+
+#addbag {
+  font-size: 15px;
+  font-weight: 300;
+  text-transform: uppercase;
+  color: #525252;
+  border: 1px solid #525252;
+  border-radius: 0%;
+  width: 76%;
 }
 
 #selectsize {
   background-color: #ffffff;
   border-color: #525252;
   border-radius: 0;
-  border-width: 2px;
+  border-width: 1px;
 }
 
 #slogan {
@@ -67,9 +116,63 @@
   font-family: 'Lato', sans-serif;
 }
 
+/* #pitch {
+  border-right: 1px solid #525252;
+} */
+
 #checked {
   font-size: 12px;
   font-weight: 300;
   color: #525252;
   font-family: 'Lato', sans-serif;
+  margin-left: 15px;
 }
+
+.selectsize {
+  background-color: #ffffff;
+  display: block;
+	font-size: 16px;
+  font-family: 'Lato', sans-serif;
+  font-weight: 300;
+  text-transform: uppercase;
+  color: #525252;
+  height: 35px;
+  width: 100%;
+  border-radius: 0;
+}
+
+.selectqty {
+  width: 80%;
+  background-color: #ffffff;
+  border-radius: 0%;
+  display: block;
+  font-size: 16px;
+  font-weight: 300;
+  font-family: 'Lato', sans-serif;
+  text-transform: uppercase;
+  color: #525252;
+  height: 35px;
+}
+
+/* #fs {
+  width: 20px;
+  height: 20px;
+  margin-left: 20px;
+  margin-top: 20px;
+} */
+
+/* #arrows {
+  margin-top: 200px;
+  margin-left: 75px;
+} */
+
+#bordered {
+  border: 1px solid #525252;
+  cursor: pointer;
+}
+/*
+.scrollable {
+  height: 420px;
+  width: 100px;
+  overflow: scroll;
+} */


### PR DESCRIPTION
With this commit, the details app will: 

- display a gallery which scrolls through images automatically, on click, and with arrow keys
- dynamically render style bubbles, which, on click, change the selected style
- dynamically render sizes based on the skus available for the selected style and product
- dynamically render quantity: 15 items, or as many items are available in stock for that product, style, and size, whichever is lesser
- dynamically render the 'pitch' and tickboxes

Known issues:
- details app currently uses the font Lato, which needs to be changed to Roboto
- lots of commented-out code; keeping this just so it's somewhere, anticipate a mass delete of commented code next pull
- spacing is messy on the side if there is only one row of style bubbles
- add to bag, review, and add to outfit functionality not yet implemented
- api is down