### PR TITLE
Implement new theme for navbar and add favicon

### DIFF
--- a/client/NavBar.jsx
+++ b/client/NavBar.jsx
@@ -4,7 +4,7 @@ import Toolbar from '@material-ui/core/Toolbar';
 import IconButton from '@material-ui/core/IconButton';
 import Typography from '@material-ui/core/Typography';
 import InputBase from '@material-ui/core/InputBase';
-import { fade, makeStyles } from '@material-ui/core/styles';
+import { fade, makeStyles, createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
 import SearchIcon from '@material-ui/icons/Search';
 
 const useStyles = makeStyles((theme) => ({
@@ -58,36 +58,49 @@ const useStyles = makeStyles((theme) => ({
         width: '20ch',
       },
     },
-  },
+  }
 }));
+
+const theme = createMuiTheme({
+  palette: {
+    primary: {
+      light: '#d2d2d2',
+      main: '#525252',
+      dark: '#141414',
+      contrastText: '#fffff',
+    }
+  }
+});
 
 export default function SearchAppBar() {
   const classes = useStyles();
 
   return (
     <div className={classes.root}>
+      <ThemeProvider theme={theme}>
       <AppBar position="static" color="primary">
         <Toolbar>
           <img src="https://media.giphy.com/media/0RbzopZZhmK17dYt7o/giphy.gif" alt="Animated Ramen" height="60"/>
-          <Typography id="title" className={classes.title} noWrap variant="h6">
+          <Typography id="maintitle" className={classes.title} noWrap variant="h6">
             Maruchan Instant Duds
           </Typography>
           {/* <div className={classes.search}>
             <div className={classes.searchIcon}>
-              <SearchIcon />
+            <SearchIcon />
             </div>
             <InputBase
-              placeholder="Search…"
-              classes={{
-                root: classes.inputRoot,
-                input: classes.inputInput,
-              }}
-              inputProps={{ 'aria-label': 'search' }}
-              onChange={(event) => { this.props.search(event.target.value); }}
+            placeholder="Search…"
+            classes={{
+              root: classes.inputRoot,
+              input: classes.inputInput,
+            }}
+            inputProps={{ 'aria-label': 'search' }}
+            onChange={(event) => { this.props.search(event.target.value); }}
             />
           </div> */}
         </Toolbar>
       </AppBar>
+          </ThemeProvider>
     </div>
   );
 }

--- a/public/index.html
+++ b/public/index.html
@@ -6,6 +6,16 @@
     <link href="https://fonts.googleapis.com/css2?family=Lato:wght@100;300;400;700;900&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="stylesheet.css">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/latest/css/bootstrap.min.css">
+    <link href="https://fonts.googleapis.com/css2?family=Lobster&display=swap" rel="stylesheet">
+    <link rel="apple-touch-icon" sizes="180x180" href="https://i.imgur.com/ZovwAb5.png/apple-touch-icon.png">
+    <link rel="apple-touch-icon" sizes="180x180" href="https://i.imgur.com/0JCLSpk.png/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="https://i.imgur.com/0JCLSpk.png/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="https://i.imgur.com/0JCLSpk.png/favicon-16x16.png">
+    <link rel="manifest" href="https://i.imgur.com/0JCLSpk.png/site.webmanifest">
+    <link rel="shortcut icon" href="https://i.imgur.com/0JCLSpk.png/favicon.ico">
+    <meta name="msapplication-TileColor" content="#da532c">
+    <meta name="msapplication-config" content="https://i.imgur.com/0JCLSpk.png/browserconfig.xml">
+    <meta name="theme-color" content="#ffffff">
   </head>
   <body>
     <div id="app"></div>

--- a/public/stylesheet.css
+++ b/public/stylesheet.css
@@ -36,6 +36,7 @@
 
 .gray {
   color: #525252 !important;
+  margin-top: -5px !important;
 }
 
 #category {
@@ -220,4 +221,12 @@
 
 #robotoFont {
   font-family: "Roboto", sans-serif !important;
+  color: #525252;
+}
+
+#maintitle {
+  color: #ffffff !important;
+  opacity: 80%;
+  margin-left: 5px;
+  font-family: "Lobster", sans-serif;
 }


### PR DESCRIPTION
With this commit, the navbar will:

- be gray in color
- display a whimsical font
- space the logo and shop name less tightly relative to each other

Additionally, the site on the whole will:
- display a ramen favicon